### PR TITLE
refactor(checks): add shared validation runner

### DIFF
--- a/js/booking-controller.js
+++ b/js/booking-controller.js
@@ -1,0 +1,189 @@
+// ==========================================
+// BOOKING CONTROLLER
+// Explicit booking trigger contract.
+// ==========================================
+(function () {
+    'use strict';
+
+    function getLocationContext() {
+        if (window.LocationContext) return window.LocationContext;
+        if (!window.TM) return null;
+        return {
+            ready: window.TM.ready,
+            get: typeof window.TM.get === 'function' ? window.TM.get.bind(window.TM) : function () { return null; },
+            getCurrent: function () { return window.TM.current || null; },
+        };
+    }
+
+    function getLocation(id) {
+        var context = getLocationContext();
+        if (!context) return null;
+        if (id && typeof context.get === 'function') return context.get(id);
+        if (typeof context.getCurrent === 'function') return context.getCurrent();
+        return null;
+    }
+
+    function normalizeLocation(value) {
+        return (value || '').toLowerCase().trim().replace(/\s+/g, '-');
+    }
+
+    function isDirectBookingUrl(href) {
+        if (!href || href === '#') return false;
+        return /^(https?:|mailto:|tel:)/i.test(href);
+    }
+
+    function resolveOpenCheckoutUrl(loc) {
+        if (!loc || loc.status === 'coming-soon') return '';
+        var roller = (loc.rollerCheckoutUrl && String(loc.rollerCheckoutUrl).trim()) || '';
+        if (roller !== '') return roller;
+        var booking = (loc.bookingUrl && String(loc.bookingUrl).trim()) || '';
+        return booking;
+    }
+
+    function tmTrack(key, payload) {
+        if (window.TMAnalytics && typeof window.TMAnalytics.track === 'function') {
+            window.TMAnalytics.track(key, payload);
+        }
+    }
+
+    function safeDestination(url) {
+        if (window.TMAnalytics && typeof window.TMAnalytics.safeDestination === 'function') {
+            return window.TMAnalytics.safeDestination(url) || url;
+        }
+        return url;
+    }
+
+    function getDestination(options) {
+        var opts = options || {};
+        var kind = String(opts.kind || 'tickets').toLowerCase();
+        var locationId = normalizeLocation(opts.locationId || '');
+        var pageLocationSlug = normalizeLocation(opts.pageLocationSlug || '');
+        var preferLocationPageFlow = !!opts.preferLocationPageFlow;
+
+        var loc = getLocation(locationId) || getLocation(pageLocationSlug) || getLocation(null);
+        if (!loc) return '';
+
+        if (kind === 'gift-cards' || kind === 'giftcards') {
+            return loc.giftCardUrl || '';
+        }
+
+        if (kind === 'groups') {
+            return loc.groupsUrl || '';
+        }
+
+        var slug = loc.slug || loc.id || locationId || pageLocationSlug;
+        if (loc.status === 'coming-soon') {
+            return slug ? '/' + slug : '';
+        }
+
+        if (preferLocationPageFlow && slug) {
+            return '/' + slug + '?book=1';
+        }
+
+        return resolveOpenCheckoutUrl(loc);
+    }
+
+    function navigate(intent) {
+        var opts = intent || {};
+        var href = opts.href;
+        if (!href && opts.currentTarget && typeof opts.currentTarget.getAttribute === 'function') {
+            href = opts.currentTarget.getAttribute('href');
+        }
+        if (!href || href === '#') {
+            if (typeof opts.openPanel === 'function') {
+                if (opts.event && typeof opts.event.preventDefault === 'function') opts.event.preventDefault();
+                opts.openPanel(opts.event);
+            }
+            return false;
+        }
+
+        var source = String(opts.source || 'generic_cta');
+        var locationSlug = normalizeLocation(opts.locationId || opts.pageLocationSlug || '');
+        var ctaId = opts.ctaId
+            || (opts.currentTarget && opts.currentTarget.className && String(opts.currentTarget.className).split(' ')[0])
+            || source;
+
+        if (opts.event && typeof opts.event.preventDefault === 'function') opts.event.preventDefault();
+
+        tmTrack('booking_click', {
+            cta_id: ctaId,
+            destination_url: safeDestination(href).split('?')[0],
+            location_slug: locationSlug,
+        });
+
+        if (/^https?:\/\//i.test(href)) {
+            tmTrack('checkout_start', {
+                destination_url: safeDestination(href),
+                location_slug: locationSlug,
+                cta_id: source,
+            });
+        }
+
+        if (opts.cleanBookParam && history.replaceState) {
+            history.replaceState(null, '', window.location.pathname);
+        }
+
+        if (opts.deferUntilLoad) {
+            window.addEventListener('load', function () {
+                setTimeout(function () {
+                    window.location.href = href;
+                }, 300);
+            });
+            return true;
+        }
+
+        window.location.assign(href);
+        return true;
+    }
+
+    function collectButtons(root, selector) {
+        return Array.prototype.slice.call(root.querySelectorAll(selector || '[data-tm-booking-trigger]'));
+    }
+
+    function attach(root, options) {
+        var opts = options || {};
+        if (!root) return function () {};
+        var selector = opts.selector || '[data-tm-booking-trigger]';
+        var openPanel = typeof opts.openPanel === 'function' ? opts.openPanel : null;
+        var pageLocationSlug = opts.pageLocationSlug || '';
+        var handler = typeof opts.handler === 'function' ? opts.handler : function (event) {
+            var btn = event.currentTarget;
+            var href = btn.getAttribute('href');
+            if (isDirectBookingUrl(href)) {
+                navigate({
+                    source: 'direct_booking',
+                    href: href,
+                    pageLocationSlug: pageLocationSlug,
+                    currentTarget: btn,
+                    event: event,
+                });
+                return;
+            }
+            if (openPanel) {
+                event.preventDefault();
+                openPanel(event);
+            }
+        };
+
+        var buttons = collectButtons(root, selector);
+        buttons.forEach(function (button) {
+            button.addEventListener('click', handler);
+        });
+        return function detach() {
+            buttons.forEach(function (button) {
+                button.removeEventListener('click', handler);
+            });
+        };
+    }
+
+    window.BookingController = {
+        attach: attach,
+        isDirectBookingUrl: isDirectBookingUrl
+    };
+    window.TMBooking = {
+        attach: attach,
+        getDestination: getDestination,
+        navigate: navigate,
+        isDirectBookingUrl: isDirectBookingUrl,
+    };
+})();

--- a/js/locations.js
+++ b/js/locations.js
@@ -79,6 +79,100 @@
         return parts.join('<br>');
     }
 
+    function normalizeLocationId(value) {
+        return String(value || '').toLowerCase().trim().replace(/\s+/g, '-');
+    }
+
+    function resolveLocationRef(id) {
+        if (!id) return TM.current;
+        const normalized = normalizeLocationId(id);
+        if (typeof TM.get === 'function') {
+            const exact = TM.get(normalized);
+            if (exact) return exact;
+        }
+        return TM.locations.find((loc) => {
+            return normalizeLocationId(loc.id) === normalized
+                || normalizeLocationId(loc.slug) === normalized
+                || normalizeLocationId(loc.shortName) === normalized
+                || normalizeLocationId(loc.name) === normalized;
+        }) || null;
+    }
+
+    function getMapQuery(loc) {
+        if (loc && loc.address) {
+            const parts = [];
+            if (loc.address.line1) parts.push(loc.address.line1);
+            if (loc.address.line2) parts.push(loc.address.line2);
+            if (loc.address.city) parts.push(loc.address.city);
+            if (loc.address.state) parts.push(loc.address.state);
+            if (loc.address.zip) parts.push(loc.address.zip);
+            if (loc.address.country) parts.push(loc.address.country);
+            if (parts.length) return encodeURIComponent(parts.join(' '));
+        }
+        if (loc && loc.mapUrl) {
+            const match = String(loc.mapUrl).match(/[?&]q=([^&]+)/i);
+            if (match && match[1]) return match[1];
+        }
+        return '';
+    }
+
+    function getInfoPanelView(id) {
+        const loc = resolveLocationRef(id);
+        if (!loc) return null;
+        const slug = loc.slug || loc.id || normalizeLocationId(id);
+        const mapQuery = getMapQuery(loc);
+        const pageUrl = slug ? '/' + slug : '/';
+        const comingSoon = loc.status === 'coming-soon';
+        const addressText = (function () {
+            if (!loc.address) return '';
+            const parts = [];
+            if (loc.address.line1) parts.push(loc.address.line1);
+            if (loc.address.line2) parts.push(loc.address.line2);
+            let cityLine = '';
+            if (loc.address.city) cityLine += loc.address.city;
+            if (loc.address.state) cityLine += (cityLine ? ', ' : '') + loc.address.state;
+            if (loc.address.zip) cityLine += (cityLine ? ' ' : '') + loc.address.zip;
+            if (cityLine) parts.push(cityLine);
+            return parts.join('\n');
+        })();
+        const hoursText = (function () {
+            if (!loc.hours) return comingSoon ? 'Coming Soon' : '';
+            const labels = { mon: 'Mon', tue: 'Tue', wed: 'Wed', thu: 'Thu', fri: 'Fri', sat: 'Sat', sun: 'Sun' };
+            const order = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'];
+            const lines = [];
+            order.forEach((day) => {
+                if (loc.hours[day] && loc.hours[day].label) {
+                    lines.push(labels[day] + ': ' + loc.hours[day].label);
+                }
+            });
+            return lines.join('\n');
+        })();
+        return {
+            name: loc.shortName || loc.name || '',
+            addressText: addressText,
+            phone: (loc.contact && loc.contact.phone) || '',
+            hoursText: hoursText,
+            pageUrl: pageUrl,
+            bookUrl: comingSoon ? pageUrl : pageUrl + '?book=1',
+            bookLabel: comingSoon ? 'Sign Up' : 'Book Now',
+            mapQuery: mapQuery,
+            mapDirectionsUrl: mapQuery ? 'https://www.google.com/maps/dir/?api=1&destination=' + mapQuery : '',
+            mapEmbedUrl: mapQuery ? 'https://www.google.com/maps?q=' + mapQuery + '&output=embed&z=12' : '',
+            comingSoon: comingSoon,
+        };
+    }
+
+    function listTicketOptions() {
+        const source = TM.locations.length ? TM.locations : Object.keys(FALLBACK).map((id) => {
+            return Object.assign({ id: id, slug: id }, FALLBACK[id]);
+        });
+        return source.map((loc) => ({
+            value: loc.id,
+            label: (loc.shortName || loc.name || loc.id) + (loc.status === 'coming-soon' ? ' (Coming Soon)' : ''),
+            status: loc.status || 'open',
+        }));
+    }
+
     let _readyResolve;
     const _readyPromise = new Promise(resolve => { _readyResolve = resolve; });
 
@@ -128,6 +222,7 @@
             // If data hasn't loaded yet, queue the selection
             if (TM.locations.length === 0) {
                 TM._pendingSelect = id;
+                try { localStorage.setItem(STORAGE_KEY, id); } catch (e) {}
                 return;
             }
             const loc = TM.get(id);
@@ -434,6 +529,60 @@
     }
 
     // Expose globally
+    const CHANGE_EVENT = 'tm:location-changed';
+    const LocationContext = {
+        ready: TM.ready,
+        async init() {
+            await TM.ready;
+        },
+        getCurrent() {
+            return TM.current;
+        },
+        getAll() {
+            return Array.isArray(TM.locations) ? TM.locations.slice() : [];
+        },
+        get(id) {
+            return typeof TM.get === 'function' ? TM.get(id) : null;
+        },
+        listTicketOptions() {
+            return listTicketOptions();
+        },
+        getInfoPanelView(id) {
+            return getInfoPanelView(id);
+        },
+        select(id) {
+            if (typeof TM.select === 'function') TM.select(id);
+        },
+        clear() {
+            if (typeof TM.clear === 'function') TM.clear();
+        },
+        resolveBookingUrl(kind, id) {
+            const loc = id ? (typeof TM.get === 'function' ? TM.get(id) : null) : TM.current;
+            if (!loc) return '';
+            const bookingKind = String(kind || 'tickets').toLowerCase();
+            if (bookingKind === 'gift-cards' || bookingKind === 'giftcards') {
+                return loc.giftCardUrl || '';
+            }
+            if (bookingKind === 'groups') {
+                return loc.groupsUrl || '';
+            }
+            if (loc.status === 'coming-soon') {
+                return '/' + (loc.slug || loc.id || '');
+            }
+            return loc.rollerCheckoutUrl || loc.bookingUrl || '';
+        },
+        subscribe(listener) {
+            if (typeof listener !== 'function') return function () {};
+            const handler = function (event) {
+                listener(event.detail || null);
+            };
+            document.addEventListener(CHANGE_EVENT, handler);
+            return function unsubscribe() {
+                document.removeEventListener(CHANGE_EVENT, handler);
+            };
+        }
+    };
+    window.LocationContext = LocationContext;
     window.TM = TM;
 
     if (document.readyState === 'loading') {

--- a/js/nav.js
+++ b/js/nav.js
@@ -4,6 +4,22 @@
 // ==========================================
 
 (function() {
+    function normalizeLocation(value) {
+        return (value || '').toLowerCase().trim().replace(/\s+/g, '-');
+    }
+
+    function getLocationContext() {
+        if (window.LocationContext) return window.LocationContext;
+        if (!window.TM) return null;
+        return {
+            ready: window.TM.ready,
+            getCurrent: function() { return window.TM.current || null; },
+            select: function(slug) {
+                if (typeof window.TM.select === 'function') window.TM.select(slug);
+            }
+        };
+    }
+
     const menuBtn = document.querySelector('.nav-menu-btn');
     const mobileMenu = document.getElementById('mobileMenu');
     const navEl = document.getElementById('nav');
@@ -12,8 +28,12 @@
     // (reads localStorage synchronously so it works before locations.json finishes loading)
     document.querySelectorAll('.nav-logo, .location-dropdown-logo').forEach(logo => {
         logo.addEventListener('click', function (e) {
-            let slug = '';
-            try { slug = localStorage.getItem('tm_location') || ''; } catch (err) {}
+            const context = getLocationContext();
+            const current = context && typeof context.getCurrent === 'function' ? context.getCurrent() : null;
+            let slug = (current && (current.slug || current.id)) || '';
+            if (!slug) {
+                try { slug = localStorage.getItem('tm_location') || ''; } catch (err) {}
+            }
             if (!slug) return; // no location — let the default index.html link work
             e.preventDefault();
             const inSubdir = window.location.pathname.includes('/locations/') || window.location.pathname.includes('/groups/');
@@ -46,14 +66,18 @@
     }
 
     // Helper to sync all location displays + localStorage
-    function syncAllLocations(city) {
+    function syncAllLocations(city, slug) {
+        const normalized = normalizeLocation(slug || city);
         const mainLocText = document.getElementById('locationText');
         if (mainLocText) mainLocText.textContent = city;
-        // Write both storage keys so every consumer agrees:
-        //   timeMissionLocation (city display name) — nav.js, ticket-panel.js
-        //   tm_location (slug)                     — nav.js logo routing, locations.js
-        localStorage.setItem('timeMissionLocation', city);
-        localStorage.setItem('tm_location', city.toLowerCase().replace(/\s+/g, '-'));
+        try {
+            localStorage.setItem('tm_location', normalized);
+            localStorage.setItem('timeMissionLocation', city);
+        } catch (err) {}
+        const context = getLocationContext();
+        if (context && typeof context.select === 'function') {
+            context.select(normalized);
+        }
         // Update hero eyebrow on mobile (function exposed by index.html)
         if (window.updateEyebrowLocation) window.updateEyebrowLocation(city);
     }
@@ -117,18 +141,19 @@
         locationLinks.forEach(link => {
             // Show info panel on hover (desktop) and click
             link.addEventListener('mouseenter', () => {
-                const cityName = link.dataset.city;
-                if (cityName) showLocationInfo(cityName);
+                const slug = getLocationSlug(link);
+                if (slug) showLocationInfo(slug);
             });
 
             link.addEventListener('click', (e) => {
                 const cityName = link.dataset.city;
+                const slug = getLocationSlug(link);
                 if (cityName) {
-                    syncAllLocations(cityName);
-                    showLocationInfo(cityName);
+                    syncAllLocations(cityName, slug);
+                    showLocationInfo(slug || cityName);
                 }
 
-                const hrefPath = (link.getAttribute('href') || '').replace(/^\//, '').replace(/\.html$/, '');
+                const hrefPath = slug;
                 if (hrefPath && window.TMAnalytics && typeof window.TMAnalytics.track === 'function') {
                     window.TMAnalytics.track('location_select', {
                         location_slug: hrefPath,
@@ -149,153 +174,79 @@
 
         // Load saved location on page load (only on location pages, not index)
         const isIndexPage = window.location.pathname === '/' || window.location.pathname.endsWith('/index.html') || window.location.pathname.endsWith('/index.htm');
-        const savedLocation = localStorage.getItem('timeMissionLocation');
-        if (savedLocation && !isIndexPage) {
-            syncAllLocations(savedLocation);
+        const context = getLocationContext();
+        if (context && context.ready && typeof context.ready.then === 'function') {
+            context.ready.then(function () {
+                if (isIndexPage) return;
+                const current = typeof context.getCurrent === 'function' ? context.getCurrent() : null;
+                if (current && current.shortName) {
+                    syncAllLocations(current.shortName, current.slug || current.id);
+                }
+            });
         }
     }
 
-    // Location data for info panel.
-    // KEEP IN SYNC WITH data/locations.json — long-term source of truth will feed this
-    // at runtime. Verified against live timemission.com on 2026-04-22.
-    const locationData = {
-        'Mount Prospect': {
-            name: 'IL – Mount Prospect',
-            address: '132 Randhurst Village Drive\nMount Prospect, IL 60056',
-            phone: '(847) 250-9560',
-            hours: 'Mon - Thurs: 12pm - 9pm\nFri: 12pm - Midnight\nSat: 10am - Midnight\nSun: 10am - 8pm',
-            bookUrl: 'https://ecom.roller.app/timemissionmountprospect/onlinecheckout/en-us/products',
-            pageUrl: '/mount-prospect',
-            mapQuery: '132+Randhurst+Village+Drive+Mount+Prospect+IL+60056'
-        },
-        'Philadelphia': {
-            name: 'PA – Philadelphia',
-            address: '1530 Chestnut Street\nPhiladelphia, PA 19102',
-            phone: '(267) 710-1240',
-            hours: 'Mon - Thurs: 12pm - 10pm\nFri: 12pm - 11pm\nSat: 10am - 11pm\nSun: 10am - 10pm',
-            bookUrl: 'https://tickets.timemission.com/onlinecheckout/en-us/products',
-            pageUrl: '/philadelphia',
-            mapQuery: '1530+Chestnut+Street+Philadelphia+PA+19102'
-        },
-        'West Nyack': {
-            name: 'NY – West Nyack',
-            address: '3532 Palisades Center Dr, Level 3\nWest Nyack, NY 10994',
-            phone: '(845) 328-4528',
-            hours: 'Mon - Thurs: 12pm - 9pm\nFri: 12pm - 11pm\nSat: 10am - 11pm\nSun: 10am - 8pm',
-            bookUrl: 'https://tickets.timemission.com/onlinecheckout/en-us/products',
-            pageUrl: '/west-nyack',
-            mapQuery: '3532+Palisades+Center+Dr+West+Nyack+NY+10994'
-        },
-        'Lincoln': {
-            name: 'RI – Lincoln',
-            address: 'R1 Indoor Karting, 100 Higginson Ave\nLincoln, RI 02865',
-            phone: '(401) 721-5554',
-            hours: 'Mon - Thurs: 12pm - 11pm\nFri: 12pm - Midnight\nSat: 9am - Midnight\nSun: 9am - 11pm',
-            bookUrl: 'https://tickets.timemission.com/onlinecheckout/en-us/products',
-            pageUrl: '/lincoln',
-            mapQuery: '100+Higginson+Ave+Lincoln+RI+02865'
-        },
-        'Houston': {
-            name: 'TX – Houston (Marq\'E)',
-            address: "Marq'E Entertainment District\nHouston, TX",
-            phone: '',
-            hours: 'Coming Soon',
-            bookUrl: '',
-            pageUrl: '/houston',
-            mapQuery: 'Marq+E+Entertainment+District+Houston+TX',
-            comingSoon: true
-        },
-        'Manassas': {
-            name: 'VA – Manassas',
-            address: 'Manassas Mall, 8300 Sudley Rd, Unit A2\nManassas, VA 20109',
-            phone: '(571) 732-1050',
-            hours: 'Mon - Thurs: 12pm - 9pm\nFri: 12pm - Midnight\nSat: 10am - Midnight\nSun: 10am - 8pm',
-            bookUrl: 'https://ecom.roller.app/timemissionmanassasmall/onlinecheckout/en-us/products',
-            pageUrl: '/manassas',
-            mapQuery: '8300+Sudley+Rd+Manassas+VA+20109'
-        },
-        'Antwerp': {
-            name: 'Belgium – Antwerp',
-            address: 'Experience Factory, Michiganstraat 1\n2030 Antwerp, Belgium',
-            phone: '+32 3 301 03 03',
-            hours: 'Mon - Fri: 2pm - 11pm\nSat - Sun: 11am - 11pm',
-            bookUrl: 'https://tickets.timemission.com/onlinecheckout/en-us/products',
-            pageUrl: '/antwerp',
-            mapQuery: 'Michiganstraat+1+Antwerp+Belgium'
-        },
-        'Orland Park': {
-            name: 'IL – Orland Park',
-            address: 'Orland Park, IL',
-            phone: '',
-            hours: 'Coming Soon',
-            bookUrl: '',
-            pageUrl: '/orland-park',
-            mapQuery: 'Orland+Park+IL',
-            comingSoon: true
-        },
-        'Dallas': {
-            name: 'TX – Dallas',
-            address: 'Dallas, TX',
-            phone: '',
-            hours: 'Coming Soon',
-            bookUrl: '',
-            pageUrl: '/dallas',
-            mapQuery: 'Dallas+TX',
-            comingSoon: true
-        },
-        'Brussels': {
-            name: 'BE – Brussels',
-            address: 'Brussels, Belgium',
-            phone: '',
-            hours: 'Coming Soon',
-            bookUrl: '',
-            pageUrl: '/brussels',
-            mapQuery: 'Brussels+Belgium',
-            comingSoon: true
+    function getLocationSlug(link) {
+        return (link.getAttribute('href') || '').replace(/^\//, '').replace(/\.html$/, '');
+    }
+
+    function setMultilineText(el, value) {
+        if (!el) return;
+        el.textContent = String(value || '');
+        el.style.whiteSpace = 'pre-line';
+    }
+
+    function renderMapEmbed(target, embedUrl) {
+        if (!target) return;
+        target.textContent = '';
+        if (!embedUrl) {
+            target.style.display = 'none';
+            return;
         }
-    };
+        const iframe = document.createElement('iframe');
+        iframe.src = embedUrl;
+        iframe.loading = 'lazy';
+        iframe.referrerPolicy = 'no-referrer-when-downgrade';
+        iframe.title = 'Map';
+        target.appendChild(iframe);
+        target.style.display = 'block';
+    }
 
     // Show location info in overlay panel
-    function showLocationInfo(cityName) {
+    function showLocationInfo(locationRef) {
         const infoPanel = document.getElementById('locationInfo');
         if (!infoPanel) return;
         const empty = infoPanel.querySelector('.location-info-empty');
         const details = infoPanel.querySelector('.location-info-details');
         const mapEl = document.getElementById('locationMap');
-        const data = locationData[cityName];
-        if (!data || !details) return;
+        const context = getLocationContext();
+        if (!context || typeof context.getInfoPanelView !== 'function' || !details) return;
+
+        const data = context.getInfoPanelView(locationRef);
+        if (!data) return;
 
         infoPanel.querySelector('.location-info-name').textContent = data.name;
         const addrEl = infoPanel.querySelector('.location-info-address');
-        addrEl.innerHTML = data.address.replace(/\n/g, '<br>');
-        addrEl.href = 'https://www.google.com/maps/dir/?api=1&destination=' + data.mapQuery;
+        setMultilineText(addrEl, data.addressText);
+        addrEl.href = data.mapDirectionsUrl || '#';
         infoPanel.querySelector('.location-info-phone').textContent = data.phone;
-        infoPanel.querySelector('.location-info-hours').innerHTML = data.hours.replace(/\n/g, '<br>');
+        setMultilineText(infoPanel.querySelector('.location-info-hours'), data.hoursText);
         var bookBtn = infoPanel.querySelector('.location-info-book');
-        if (data.comingSoon) {
-            bookBtn.href = data.pageUrl;
-            bookBtn.textContent = 'Sign Up';
-        } else {
-            bookBtn.href = data.pageUrl + '?book=1';
-            bookBtn.textContent = 'Book Now';
-        }
+        bookBtn.href = data.bookUrl || data.pageUrl || '#';
+        bookBtn.textContent = data.bookLabel || 'Book Now';
 
-        // Show map embed
-        if (mapEl && data.mapQuery) {
-            mapEl.innerHTML = '<iframe src="https://www.google.com/maps?q=' + data.mapQuery + '&output=embed&z=12" loading="lazy" referrerpolicy="no-referrer-when-downgrade" title="Map"></iframe>';
-            mapEl.style.display = 'block';
-        }
+        renderMapEmbed(mapEl, data.mapEmbedUrl);
 
         if (empty) empty.style.display = 'none';
         details.style.display = 'block';
     }
 
     // Show info for saved location on load
-    const savedLoc = localStorage.getItem('timeMissionLocation');
-    if (savedLoc) showLocationInfo(savedLoc);
-
-    // Update booking URLs based on selected location
-    const bookingUrls = locationData;
-    const bookingButtons = document.querySelectorAll('.btn-tickets, .btn-primary[href*="roller"], .btn-nav[href*="roller"]');
-    // URL updating will be handled when location-specific URLs are ready
+    const contextForInfo = getLocationContext();
+    if (contextForInfo && contextForInfo.ready && typeof contextForInfo.ready.then === 'function') {
+        contextForInfo.ready.then(function () {
+            const current = typeof contextForInfo.getCurrent === 'function' ? contextForInfo.getCurrent() : null;
+            if (current && (current.id || current.slug)) showLocationInfo(current.id || current.slug);
+        });
+    }
 })();

--- a/js/ticket-panel.js
+++ b/js/ticket-panel.js
@@ -1,8 +1,6 @@
 // ==========================================
 // TICKET POPUP PANEL — Shared across all pages
-// Single source of truth for booking logic
-// On index: Book Now opens ticket panel, Continue routes through location page
-// On location pages: Book Now navigates directly to booking
+// Ticket panel UI + TMBooking integration
 // Supports ?book=1 auto-redirect from ticket panel flow
 // ==========================================
 (function () {
@@ -13,6 +11,29 @@
     var ticketClose = document.getElementById('ticketClose');
     var ticketLocationSelect = document.getElementById('ticketLocation');
     var ticketBookBtn = document.getElementById('ticketBookBtn');
+    var pageLocation = document.body.dataset.location || '';
+
+    function getLocationContext() {
+        if (window.LocationContext) return window.LocationContext;
+        if (!window.TM) return null;
+        return {
+            ready: window.TM.ready,
+            get: typeof window.TM.get === 'function' ? window.TM.get.bind(window.TM) : function () { return null; },
+            getCurrent: function () { return window.TM.current || null; },
+            resolveBookingUrl: function (kind, id) {
+                var loc = id && typeof window.TM.get === 'function' ? window.TM.get(id) : window.TM.current;
+                if (!loc) return '';
+                if (kind === 'gift-cards' || kind === 'giftcards') return loc.giftCardUrl || '';
+                if (loc.status === 'coming-soon') return '/' + (loc.slug || loc.id || '');
+                return loc.rollerCheckoutUrl || loc.bookingUrl || '';
+            }
+        };
+    }
+
+    function getTMBooking() {
+        if (window.TMBooking) return window.TMBooking;
+        return null;
+    }
 
     function tmTrack(key, payload) {
         if (window.TMAnalytics && typeof window.TMAnalytics.track === 'function') {
@@ -24,35 +45,20 @@
         return (value || '').toLowerCase().trim().replace(/\s+/g, '-');
     }
 
-    function getLocation(id) {
-        var normalized = normalizeLocation(id);
-        if (window.TM && typeof window.TM.get === 'function') {
-            return window.TM.get(normalized);
-        }
-        return null;
-    }
-
-    function getLocationPage(id) {
-        var loc = getLocation(id);
-        var slug = (loc && loc.slug) || normalizeLocation(id);
-        return '/' + slug;
-    }
-
-    // Phase 5 BOOK-01 / D-03: rollerCheckoutUrl precedes bookingUrl for open venues.
-    function resolveOpenCheckoutUrl(loc) {
-        if (!loc) return '';
-        if (loc.status === 'coming-soon') return '';
-        var roller = (loc.rollerCheckoutUrl && String(loc.rollerCheckoutUrl).trim()) || '';
-        if (roller !== '') return roller;
-        var book = (loc.bookingUrl && String(loc.bookingUrl).trim()) || '';
-        return book;
-    }
-
     function getBookingUrl(id) {
-        var loc = getLocation(id);
-        if (!loc) return '';
-        if (loc.status === 'coming-soon') return getLocationPage(loc.id);
-        return resolveOpenCheckoutUrl(loc);
+        var booking = getTMBooking();
+        if (booking && typeof booking.getDestination === 'function') {
+            return booking.getDestination({
+                kind: 'tickets',
+                locationId: id,
+                pageLocationSlug: pageLocation,
+                preferLocationPageFlow: !pageLocation,
+            });
+        }
+
+        var context = getLocationContext();
+        if (!context || typeof context.resolveBookingUrl !== 'function') return '';
+        return context.resolveBookingUrl('tickets', id);
     }
 
     function syncLocationOptions() {
@@ -68,34 +74,25 @@
         if (currentValue) ticketLocationSelect.value = currentValue;
     }
 
-    // Detect if this is a location page (body has data-location attribute)
-    var pageLocation = document.body.dataset.location || '';
-
     // --- Auto-redirect: location pages with ?book=1 go straight to booking ---
     function scheduleAutoRedirect() {
-        // Clean the URL so the back button doesn't trigger redirect again
-        if (history.replaceState) {
-            history.replaceState(null, '', window.location.pathname);
-        }
         var autoUrl = getBookingUrl(pageLocation);
-        if (autoUrl) {
-            // Wait for page to fully load so the history entry is established,
-            // then redirect — back button will return to this location page
-            window.addEventListener('load', function () {
-                setTimeout(function () {
-                    if (/^https?:\/\//i.test(autoUrl)) {
-                        tmTrack('checkout_start', {
-                            destination_url:
-                                (window.TMAnalytics && window.TMAnalytics.safeDestination
-                                    ? window.TMAnalytics.safeDestination(autoUrl)
-                                    : autoUrl) || autoUrl,
-                            location_slug: pageLocation,
-                            cta_id: 'book_param_auto',
-                        });
-                    }
-                    window.location.href = autoUrl;
-                }, 300);
+        var booking = getTMBooking();
+        if (autoUrl && booking && typeof booking.navigate === 'function') {
+            booking.navigate({
+                source: 'book_param_auto',
+                ctaId: 'book_param_auto',
+                href: autoUrl,
+                locationId: pageLocation,
+                cleanBookParam: true,
+                deferUntilLoad: true,
             });
+            return;
+        }
+
+        if (autoUrl) {
+            if (history.replaceState) history.replaceState(null, '', window.location.pathname);
+            window.location.href = autoUrl;
         }
     }
 
@@ -113,28 +110,21 @@
     function syncBookingBtn() {
         if (!ticketBookBtn) return;
         var selected = ticketLocationSelect.value;
-        var page = getLocationPage(selected);
-        // On index/non-location pages: route through location page
-        // On location pages: go directly to booking
-        if (!pageLocation && page) {
-            ticketBookBtn.href = page + '?book=1';
-        } else {
-            var url = getBookingUrl(selected);
-            ticketBookBtn.href = url || '#';
-        }
+        var url = getBookingUrl(selected);
+        ticketBookBtn.href = url || '#';
     }
 
     // Open ticket panel
     function openTicketPanel(e) {
-        // On location pages, if the clicked button has a real booking URL, navigate directly
-        if (pageLocation && e && e.currentTarget && e.currentTarget.href && !e.currentTarget.href.endsWith('#')) {
-            return; // Let the link navigate normally
-        }
         if (e) e.preventDefault();
 
         // Pre-select saved location if available
         var saved = '';
-        try { saved = localStorage.getItem('tm_location') || localStorage.getItem('timeMissionLocation') || ''; } catch (err) {}
+        var context = getLocationContext();
+        var current = context && typeof context.getCurrent === 'function' ? context.getCurrent() : null;
+        if (current && (current.id || current.slug)) {
+            saved = current.id || current.slug;
+        }
         if (saved && ticketLocationSelect) {
             ticketLocationSelect.value = normalizeLocation(saved);
         }
@@ -160,56 +150,19 @@
 
     // A URL is "direct" if it's an http(s) booking URL or a mailto/tel scheme —
     // in any of those cases we navigate straight there instead of opening the panel.
-    function isDirectBookingUrl(href) {
-        if (!href || href === '#') return false;
-        return /^(https?:|mailto:|tel:)/i.test(href);
+    // TMBooking owns this policy and invokes openTicketPanel only when needed.
+    var booking = getTMBooking();
+    if (booking && typeof booking.attach === 'function') {
+        booking.attach(document, {
+            selector: '[data-tm-booking-trigger]',
+            pageLocationSlug: pageLocation,
+            openPanel: openTicketPanel,
+        });
+    } else {
+        document.querySelectorAll('[data-tm-booking-trigger]').forEach(function (button) {
+            button.addEventListener('click', openTicketPanel);
+        });
     }
-
-    // Unified handler: if button has a direct URL, navigate; otherwise open the
-    // ticket panel so the user can pick a location.
-    function bookOrOpenPanel(e) {
-        var btn = e.currentTarget;
-        var href = btn.getAttribute('href');
-        if (isDirectBookingUrl(href)) {
-            e.preventDefault();
-            tmTrack('booking_click', {
-                cta_id: (btn.className && String(btn.className).split(' ')[0]) || 'booking_hero',
-                destination_url:
-                    window.TMAnalytics && window.TMAnalytics.safeDestination
-                        ? window.TMAnalytics.safeDestination(href) || ''
-                        : '',
-                location_slug: pageLocation || '',
-            });
-            if (/^(mailto:|tel:)/i.test(href)) {
-                window.location.href = href;
-            } else {
-                if (/^https?:\/\//i.test(href)) {
-                    tmTrack('checkout_start', {
-                        destination_url:
-                            (window.TMAnalytics && window.TMAnalytics.safeDestination
-                                ? window.TMAnalytics.safeDestination(href)
-                                : '') || '',
-                        location_slug: pageLocation || '',
-                        cta_id: 'direct_booking',
-                    });
-                }
-                // D-01: same-tab default for external checkout (Phase 5).
-                window.location.assign(href);
-            }
-            return;
-        }
-        // No location — open ticket panel to choose
-        openTicketPanel(e);
-    }
-
-    // Attach to all booking buttons site-wide
-    var bookingButtons = document.querySelectorAll(
-        '.btn-tickets, .btn-book-now, ' +
-        '.btn-primary[href*="roller"], .btn-nav[href*="roller"], .btn-primary[href*="tickets.timemission"]'
-    );
-    bookingButtons.forEach(function (btn) {
-        btn.addEventListener('click', bookOrOpenPanel);
-    });
 
     // Close handlers
     if (ticketClose) ticketClose.addEventListener('click', closeTicketPanel);
@@ -229,8 +182,9 @@
         });
     });
 
-    if (window.TM && window.TM.ready) {
-        window.TM.ready.then(function () {
+    var locationContext = getLocationContext();
+    if (locationContext && locationContext.ready && typeof locationContext.ready.then === 'function') {
+        locationContext.ready.then(function () {
             syncLocationOptions();
             syncBookingBtn();
         });
@@ -243,25 +197,23 @@
             e.preventDefault();
             var url = ticketBookBtn.getAttribute('href');
             if (url && url !== '#') {
-                tmTrack('booking_click', {
-                    cta_id: 'ticket_panel_continue',
-                    location_slug: ticketLocationSelect ? ticketLocationSelect.value : '',
-                    destination_url:
-                        window.TMAnalytics && window.TMAnalytics.safeDestination
-                            ? window.TMAnalytics.safeDestination(url) || url.split('?')[0]
-                            : url.split('?')[0],
-                });
-                if (/^https?:\/\//i.test(url)) {
-                    tmTrack('checkout_start', {
-                        destination_url:
-                            (window.TMAnalytics && window.TMAnalytics.safeDestination
-                                ? window.TMAnalytics.safeDestination(url)
-                                : '') || '',
-                        location_slug: ticketLocationSelect ? ticketLocationSelect.value : '',
-                        cta_id: 'ticket_panel_continue',
+                var bookingGateway = getTMBooking();
+                if (bookingGateway && typeof bookingGateway.navigate === 'function') {
+                    bookingGateway.navigate({
+                        source: 'ticket_panel_continue',
+                        ctaId: 'ticket_panel_continue',
+                        href: url,
+                        locationId: ticketLocationSelect ? ticketLocationSelect.value : '',
+                        event: e,
                     });
+                } else {
+                    tmTrack('booking_click', {
+                        cta_id: 'ticket_panel_continue',
+                        location_slug: ticketLocationSelect ? ticketLocationSelect.value : '',
+                        destination_url: url.split('?')[0],
+                    });
+                    window.location.href = url;
                 }
-                window.location.href = url;
             }
         });
     }

--- a/js/ticket-panel.js
+++ b/js/ticket-panel.js
@@ -62,13 +62,26 @@
     }
 
     function syncLocationOptions() {
-        if (!window.TM || !Array.isArray(window.TM.locations) || !ticketLocationSelect) return;
+        if (!ticketLocationSelect) return;
+        var context = getLocationContext();
+        var options = [];
+        if (context && typeof context.listTicketOptions === 'function') {
+            options = context.listTicketOptions();
+        } else if (window.TM && Array.isArray(window.TM.locations)) {
+            options = window.TM.locations.map(function (loc) {
+                return {
+                    value: loc.id,
+                    label: loc.shortName + (loc.status === 'coming-soon' ? ' (Coming Soon)' : ''),
+                };
+            });
+        }
+        if (!options.length) return;
         var currentValue = ticketLocationSelect.value;
         ticketLocationSelect.textContent = '';
-        window.TM.locations.forEach(function (loc) {
+        options.forEach(function (entry) {
             var option = document.createElement('option');
-            option.value = loc.id;
-            option.textContent = loc.shortName + (loc.status === 'coming-soon' ? ' (Coming Soon)' : '');
+            option.value = entry.value;
+            option.textContent = entry.label;
             ticketLocationSelect.appendChild(option);
         });
         if (currentValue) ticketLocationSelect.value = currentValue;

--- a/scripts/check-booking-architecture.js
+++ b/scripts/check-booking-architecture.js
@@ -6,6 +6,7 @@ const errors = [];
 
 const ticketPanel = fs.readFileSync(path.join(root, 'js', 'ticket-panel.js'), 'utf8');
 const rollerCheckout = fs.readFileSync(path.join(root, 'js', 'roller-checkout.js'), 'utf8');
+const bookingController = fs.readFileSync(path.join(root, 'js', 'booking-controller.js'), 'utf8');
 
 if (/var\s+bookingUrls\s*=|const\s+bookingUrls\s*=|let\s+bookingUrls\s*=/.test(ticketPanel)) {
   errors.push('js/ticket-panel.js must not define a bookingUrls map; use data/locations.json via window.TM');
@@ -23,12 +24,40 @@ if (!ticketPanel.includes('window.TM.ready')) {
   errors.push('js/ticket-panel.js should wait for window.TM.ready before hydrating location-driven options');
 }
 
-if (!ticketPanel.includes('resolveOpenCheckoutUrl')) {
-  errors.push('js/ticket-panel.js must define resolveOpenCheckoutUrl for Phase 5 checkout precedence');
+if (!ticketPanel.includes('window.TMBooking') && !ticketPanel.includes('getTMBooking')) {
+  errors.push('js/ticket-panel.js must use TMBooking gateway for booking decisions');
 }
 
-if (!ticketPanel.match(/function resolveOpenCheckoutUrl[\s\S]*?rollerCheckoutUrl[\s\S]*?bookingUrl/)) {
-  errors.push('resolveOpenCheckoutUrl must test rollerCheckoutUrl before bookingUrl');
+if (!bookingController.includes('window.TMBooking')) {
+  errors.push('js/booking-controller.js must expose window.TMBooking gateway');
+}
+
+if (!bookingController.includes('getDestination')) {
+  errors.push('window.TMBooking must provide getDestination');
+}
+
+if (!bookingController.includes('navigate')) {
+  errors.push('window.TMBooking must provide navigate');
+}
+
+if (!ticketPanel.includes('[data-tm-booking-trigger]')) {
+  errors.push('js/ticket-panel.js must bind booking handlers via explicit [data-tm-booking-trigger] selectors');
+}
+
+if (
+  ticketPanel.includes('.btn-tickets, .btn-book-now')
+  || ticketPanel.includes('btn-primary[href*="roller"]')
+  || ticketPanel.includes('btn-primary[href*="tickets.timemission"]')
+) {
+  errors.push('js/ticket-panel.js must not use heuristic booking selectors; use [data-tm-booking-trigger]');
+}
+
+if (
+  bookingController.includes('.btn-tickets, .btn-book-now')
+  || bookingController.includes('btn-primary[href*="roller"]')
+  || bookingController.includes('btn-primary[href*="tickets.timemission"]')
+) {
+  errors.push('js/booking-controller.js must not use heuristic booking selectors; use [data-tm-booking-trigger]');
 }
 
 // BOOK-03: roller-checkout.js is a loadable no-op stub; iframe CDN must not ship by default.

--- a/scripts/check-booking-architecture.js
+++ b/scripts/check-booking-architecture.js
@@ -1,82 +1,82 @@
 const fs = require('node:fs');
 const path = require('node:path');
+const { runCheck } = require('./lib/validation-core');
 
 const root = path.resolve(__dirname, '..');
-const errors = [];
 
 const ticketPanel = fs.readFileSync(path.join(root, 'js', 'ticket-panel.js'), 'utf8');
 const rollerCheckout = fs.readFileSync(path.join(root, 'js', 'roller-checkout.js'), 'utf8');
 const bookingController = fs.readFileSync(path.join(root, 'js', 'booking-controller.js'), 'utf8');
 
-if (/var\s+bookingUrls\s*=|const\s+bookingUrls\s*=|let\s+bookingUrls\s*=/.test(ticketPanel)) {
-  errors.push('js/ticket-panel.js must not define a bookingUrls map; use data/locations.json via window.TM');
-}
+runCheck({
+  title: 'Booking architecture check',
+  run(errors) {
+    if (/var\s+bookingUrls\s*=|const\s+bookingUrls\s*=|let\s+bookingUrls\s*=/.test(ticketPanel)) {
+      errors.push('js/ticket-panel.js must not define a bookingUrls map; use data/locations.json via window.TM');
+    }
 
-if (/var\s+locationPages\s*=|const\s+locationPages\s*=|let\s+locationPages\s*=/.test(ticketPanel)) {
-  errors.push('js/ticket-panel.js must not define a locationPages map; derive pages from location slugs');
-}
+    if (/var\s+locationPages\s*=|const\s+locationPages\s*=|let\s+locationPages\s*=/.test(ticketPanel)) {
+      errors.push('js/ticket-panel.js must not define a locationPages map; derive pages from location slugs');
+    }
 
-if (/rollerCheckouts\s*=/.test(rollerCheckout)) {
-  errors.push('js/roller-checkout.js must not define rollerCheckouts; use location.rollerCheckoutUrl');
-}
+    if (/rollerCheckouts\s*=/.test(rollerCheckout)) {
+      errors.push('js/roller-checkout.js must not define rollerCheckouts; use location.rollerCheckoutUrl');
+    }
 
-if (!ticketPanel.includes('window.TM.ready')) {
-  errors.push('js/ticket-panel.js should wait for window.TM.ready before hydrating location-driven options');
-}
+    if (!ticketPanel.includes('window.TM.ready')) {
+      errors.push('js/ticket-panel.js should wait for window.TM.ready before hydrating location-driven options');
+    }
 
-if (!ticketPanel.includes('window.TMBooking') && !ticketPanel.includes('getTMBooking')) {
-  errors.push('js/ticket-panel.js must use TMBooking gateway for booking decisions');
-}
+    if (!ticketPanel.includes('window.TMBooking') && !ticketPanel.includes('getTMBooking')) {
+      errors.push('js/ticket-panel.js must use TMBooking gateway for booking decisions');
+    }
 
-if (!bookingController.includes('window.TMBooking')) {
-  errors.push('js/booking-controller.js must expose window.TMBooking gateway');
-}
+    if (!bookingController.includes('window.TMBooking')) {
+      errors.push('js/booking-controller.js must expose window.TMBooking gateway');
+    }
 
-if (!bookingController.includes('getDestination')) {
-  errors.push('window.TMBooking must provide getDestination');
-}
+    if (!bookingController.includes('getDestination')) {
+      errors.push('window.TMBooking must provide getDestination');
+    }
 
-if (!bookingController.includes('navigate')) {
-  errors.push('window.TMBooking must provide navigate');
-}
+    if (!bookingController.includes('navigate')) {
+      errors.push('window.TMBooking must provide navigate');
+    }
 
-if (!ticketPanel.includes('[data-tm-booking-trigger]')) {
-  errors.push('js/ticket-panel.js must bind booking handlers via explicit [data-tm-booking-trigger] selectors');
-}
+    if (!ticketPanel.includes('[data-tm-booking-trigger]')) {
+      errors.push('js/ticket-panel.js must bind booking handlers via explicit [data-tm-booking-trigger] selectors');
+    }
 
-if (
-  ticketPanel.includes('.btn-tickets, .btn-book-now')
-  || ticketPanel.includes('btn-primary[href*="roller"]')
-  || ticketPanel.includes('btn-primary[href*="tickets.timemission"]')
-) {
-  errors.push('js/ticket-panel.js must not use heuristic booking selectors; use [data-tm-booking-trigger]');
-}
+    if (
+      ticketPanel.includes('.btn-tickets, .btn-book-now')
+      || ticketPanel.includes('btn-primary[href*="roller"]')
+      || ticketPanel.includes('btn-primary[href*="tickets.timemission"]')
+    ) {
+      errors.push('js/ticket-panel.js must not use heuristic booking selectors; use [data-tm-booking-trigger]');
+    }
 
-if (
-  bookingController.includes('.btn-tickets, .btn-book-now')
-  || bookingController.includes('btn-primary[href*="roller"]')
-  || bookingController.includes('btn-primary[href*="tickets.timemission"]')
-) {
-  errors.push('js/booking-controller.js must not use heuristic booking selectors; use [data-tm-booking-trigger]');
-}
+    if (
+      bookingController.includes('.btn-tickets, .btn-book-now')
+      || bookingController.includes('btn-primary[href*="roller"]')
+      || bookingController.includes('btn-primary[href*="tickets.timemission"]')
+    ) {
+      errors.push('js/booking-controller.js must not use heuristic booking selectors; use [data-tm-booking-trigger]');
+    }
 
-// BOOK-03: roller-checkout.js is a loadable no-op stub; iframe CDN must not ship by default.
-if (rollerCheckout.includes('checkout_iframe.js')) {
-  errors.push('js/roller-checkout.js must not load Roller iframe CDN (BOOK-03)');
-}
+    // BOOK-03: roller-checkout.js is a loadable no-op stub; iframe CDN must not ship by default.
+    if (rollerCheckout.includes('checkout_iframe.js')) {
+      errors.push('js/roller-checkout.js must not load Roller iframe CDN (BOOK-03)');
+    }
 
-if (rollerCheckout.includes('RollerCheckout')) {
-  errors.push('js/roller-checkout.js must not reference RollerCheckout (BOOK-03)');
-}
+    if (rollerCheckout.includes('RollerCheckout')) {
+      errors.push('js/roller-checkout.js must not reference RollerCheckout (BOOK-03)');
+    }
 
-if (rollerCheckout.includes('cdn.rollerdigital.com')) {
-  errors.push('js/roller-checkout.js must not reference cdn.rollerdigital.com (BOOK-03)');
-}
-
-if (errors.length) {
-  console.error('Booking architecture check failed:');
-  for (const error of errors) console.error(`- ${error}`);
-  process.exit(1);
-}
-
-console.log('Booking architecture check passed.');
+    if (rollerCheckout.includes('cdn.rollerdigital.com')) {
+      errors.push('js/roller-checkout.js must not reference cdn.rollerdigital.com (BOOK-03)');
+    }
+  },
+  onSuccess() {
+    return 'Booking architecture check passed.';
+  },
+});

--- a/scripts/check-components.js
+++ b/scripts/check-components.js
@@ -1,54 +1,34 @@
 const fs = require('node:fs');
 const path = require('node:path');
+const { listDeployableHtmlPages, runCheck } = require('./lib/validation-core');
 
 const root = path.resolve(__dirname, '..');
-const errors = [];
+const runtimePages = listDeployableHtmlPages(root).filter(
+  (filePath) => path.relative(root, filePath) !== '404.html'
+);
 
-function walk(dir, files = []) {
-  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-    if (entry.name.startsWith('.') || entry.name === 'node_modules') continue;
-    const fullPath = path.join(dir, entry.name);
-    if (entry.isDirectory()) {
-      walk(fullPath, files);
-    } else if (entry.name.endsWith('.html')) {
-      files.push(fullPath);
+runCheck({
+  title: 'Component drift check',
+  run(errors) {
+    for (const filePath of runtimePages) {
+      const relative = path.relative(root, filePath);
+      const content = fs.readFileSync(filePath, 'utf8');
+      const usesTicketPanel = content.includes('js/ticket-panel.js') || content.includes('<!-- Ticket Popup Panel -->');
+
+      if (usesTicketPanel && !content.includes('id="ticketPanel"')) {
+        errors.push(`${relative} is missing #ticketPanel`);
+      }
+
+      if (content.includes('id="ticketClose"') && !content.includes('id="ticketClose" aria-label="Close ticket panel"')) {
+        errors.push(`${relative} has an unlabeled ticket panel close button`);
+      }
+
+      if (content.includes('js/ticket-panel.js') && !content.includes('<!-- Ticket Popup Panel -->')) {
+        errors.push(`${relative} loads ticket-panel.js without the ticket panel marker`);
+      }
     }
-  }
-  return files;
-}
-
-const runtimePages = walk(root).filter((filePath) => {
-  const relative = path.relative(root, filePath);
-  return !relative.startsWith('assets/')
-    && !relative.startsWith('ads/')
-    && !relative.startsWith('components/')
-    && !relative.startsWith('dist/')
-    && !relative.startsWith('public/')
-    && relative !== '404.html';
+  },
+  onSuccess() {
+    return `Component drift check passed for ${runtimePages.length} runtime pages.`;
+  },
 });
-
-for (const filePath of runtimePages) {
-  const relative = path.relative(root, filePath);
-  const content = fs.readFileSync(filePath, 'utf8');
-  const usesTicketPanel = content.includes('js/ticket-panel.js') || content.includes('<!-- Ticket Popup Panel -->');
-
-  if (usesTicketPanel && !content.includes('id="ticketPanel"')) {
-    errors.push(`${relative} is missing #ticketPanel`);
-  }
-
-  if (content.includes('id="ticketClose"') && !content.includes('id="ticketClose" aria-label="Close ticket panel"')) {
-    errors.push(`${relative} has an unlabeled ticket panel close button`);
-  }
-
-  if (content.includes('js/ticket-panel.js') && !content.includes('<!-- Ticket Popup Panel -->')) {
-    errors.push(`${relative} loads ticket-panel.js without the ticket panel marker`);
-  }
-}
-
-if (errors.length) {
-  console.error('Component drift check failed:');
-  for (const error of errors) console.error(`- ${error}`);
-  process.exit(1);
-}
-
-console.log(`Component drift check passed for ${runtimePages.length} runtime pages.`);

--- a/scripts/check-route-contract.js
+++ b/scripts/check-route-contract.js
@@ -2,6 +2,12 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
+const {
+  loadRouteRegistry,
+  compileRouteContract,
+  verifySitemapXml,
+} = require('./lib/route-artifacts');
+const { normalizeCanonicalPath } = require('./lib/validation-core');
 
 const root = path.resolve(__dirname, '..');
 
@@ -96,22 +102,11 @@ function parseArgs(argv) {
 }
 
 function readRegistry() {
-  const registryPath = path.join(root, 'src/data/routes.json');
-  const raw = fs.readFileSync(registryPath, 'utf8');
-  return JSON.parse(raw);
+  return loadRouteRegistry(root);
 }
 
 function normalizePath(p) {
-  if (!p || typeof p !== 'string') return '';
-  let s = stripQueryAndHash(p.trim());
-  if (s.startsWith('https://timemission.com')) {
-    s = s.slice('https://timemission.com'.length);
-  } else if (s.startsWith('http://timemission.com')) {
-    s = s.slice('http://timemission.com'.length);
-  }
-  if (!s.startsWith('/')) s = `/${s}`;
-  if (s.length > 1 && s.endsWith('/')) s = s.slice(0, -1);
-  return s;
+  return normalizeCanonicalPath(p);
 }
 
 function stripQueryAndHash(value) {
@@ -261,34 +256,11 @@ function validateSitemap(registry, errors) {
     return;
   }
   const xml = fs.readFileSync(sitemapPath, 'utf8');
-  const locRe = /<loc>([^<]+)<\/loc>/g;
-  const locs = [...xml.matchAll(locRe)].map((m) => m[1]);
-
-  if (locs.some((u) => u.includes('.html'))) {
-    errors.push('sitemap.xml contains .html URLs');
-  }
-
-  const expected = new Set();
-  for (const route of registry.routes) {
-    if (!route.sitemap) continue;
-    const url =
-      route.canonicalPath === '/'
-        ? `${registry.baseUrl}/`
-        : `${registry.baseUrl}${route.canonicalPath}`;
-    expected.add(url);
-  }
-
-  for (const url of locs) {
-    if (!expected.has(url)) {
-      errors.push(`unexpected or unknown sitemap loc ${url}`);
-    }
-  }
-
-  for (const url of expected) {
-    if (!locs.includes(url)) {
-      errors.push(`missing sitemap loc ${url}`);
-    }
-  }
+  const contract = compileRouteContract(registry);
+  const result = verifySitemapXml(xml, contract);
+  result.errors.forEach((error) => {
+    errors.push(error.replace(/^Sitemap\s/, 'sitemap '));
+  });
 }
 
 function resolveScopeFiles(scope) {

--- a/scripts/check-sitemap-output.js
+++ b/scripts/check-sitemap-output.js
@@ -1,11 +1,9 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const { loadRouteRegistry, compileRouteContract, verifySitemapXml } = require('./lib/route-artifacts');
-const { printCheckErrors } = require('./lib/validation-core');
+const { runCheck } = require('./lib/validation-core');
 
 const root = path.resolve(__dirname, '..');
-const errors = [];
-
 const registry = loadRouteRegistry(root);
 const contract = compileRouteContract(registry);
 
@@ -17,15 +15,16 @@ if (!fs.existsSync(distPath)) {
 }
 
 const xml = fs.readFileSync(distPath, 'utf8');
-errors.push(...verifySitemapXml(xml, contract, {
-    requireXmlHeader: true,
-    requireXmlns: true,
-    requireBaseUrl: true,
-}).errors);
-
-if (errors.length) {
-    printCheckErrors('Sitemap output check', errors);
-    process.exit(1);
-}
-
-console.log(`Sitemap output check passed for ${contract.sitemapUrls.length} URLs.`);
+runCheck({
+    title: 'Sitemap output check',
+    run(errors) {
+        errors.push(...verifySitemapXml(xml, contract, {
+            requireXmlHeader: true,
+            requireXmlns: true,
+            requireBaseUrl: true,
+        }).errors);
+    },
+    onSuccess() {
+        return `Sitemap output check passed for ${contract.sitemapUrls.length} URLs.`;
+    },
+});

--- a/scripts/check-sitemap-output.js
+++ b/scripts/check-sitemap-output.js
@@ -1,11 +1,13 @@
 const fs = require('node:fs');
 const path = require('node:path');
+const { loadRouteRegistry, compileRouteContract, verifySitemapXml } = require('./lib/route-artifacts');
+const { printCheckErrors } = require('./lib/validation-core');
 
 const root = path.resolve(__dirname, '..');
 const errors = [];
 
-const registryPath = path.join(root, 'src/data/routes.json');
-const registry = JSON.parse(fs.readFileSync(registryPath, 'utf8'));
+const registry = loadRouteRegistry(root);
+const contract = compileRouteContract(registry);
 
 const distPath = path.join(root, 'dist', 'sitemap.xml');
 if (!fs.existsSync(distPath)) {
@@ -14,58 +16,16 @@ if (!fs.existsSync(distPath)) {
     process.exit(1);
 }
 
-const expectedUrls = [];
-for (const route of registry.routes) {
-    if (!route.sitemap) continue;
-    const url =
-        route.canonicalPath === '/'
-            ? `${registry.baseUrl}/`
-            : `${registry.baseUrl}${route.canonicalPath}`;
-    expectedUrls.push(url);
-}
-
-const expectedSet = new Set(expectedUrls);
 const xml = fs.readFileSync(distPath, 'utf8');
-
-if (!xml.startsWith('<?xml version="1.0" encoding="UTF-8"?>')) {
-    errors.push('dist/sitemap.xml must start with <?xml version="1.0" encoding="UTF-8"?>');
-}
-if (!xml.includes('xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"')) {
-    errors.push('dist/sitemap.xml must declare sitemap 0.9 xmlns');
-}
-
-const locRe = /<loc>([^<]+)<\/loc>/g;
-const locs = [...xml.matchAll(locRe)].map((m) => m[1]);
-
-for (const loc of locs) {
-    if (loc.includes('.html')) {
-        errors.push(`Sitemap contains legacy .html URL: ${loc}`);
-    }
-    const rootHome = `${registry.baseUrl}/`;
-    if (loc.endsWith('/') && loc !== rootHome) {
-        errors.push(`Sitemap loc must not end with trailing slash except root: ${loc}`);
-    }
-    if (!loc.startsWith(registry.baseUrl)) {
-        errors.push(`Sitemap loc must use base URL ${registry.baseUrl}: ${loc}`);
-    }
-}
-
-for (const url of expectedUrls) {
-    if (!locs.includes(url)) {
-        errors.push(`Missing sitemap URL: ${url}`);
-    }
-}
-
-for (const loc of locs) {
-    if (!expectedSet.has(loc)) {
-        errors.push(`Unexpected sitemap URL: ${loc}`);
-    }
-}
+errors.push(...verifySitemapXml(xml, contract, {
+    requireXmlHeader: true,
+    requireXmlns: true,
+    requireBaseUrl: true,
+}).errors);
 
 if (errors.length) {
-    console.error('Sitemap output check failed:');
-    for (const error of errors) console.error(`- ${error}`);
+    printCheckErrors('Sitemap output check', errors);
     process.exit(1);
 }
 
-console.log(`Sitemap output check passed for ${expectedUrls.length} URLs.`);
+console.log(`Sitemap output check passed for ${contract.sitemapUrls.length} URLs.`);

--- a/scripts/check-sitemap.js
+++ b/scripts/check-sitemap.js
@@ -1,21 +1,21 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const { loadRouteRegistry, compileRouteContract, verifySitemapXml } = require('./lib/route-artifacts');
-const { printCheckErrors } = require('./lib/validation-core');
+const { runCheck } = require('./lib/validation-core');
 
 const root = path.resolve(__dirname, '..');
-const errors = [];
-
 const registry = loadRouteRegistry(root);
 const contract = compileRouteContract(registry);
 
 const sitemapPath = path.join(root, 'sitemap.xml');
 const xml = fs.readFileSync(sitemapPath, 'utf8');
-errors.push(...verifySitemapXml(xml, contract).errors);
 
-if (errors.length) {
-  printCheckErrors('Sitemap check', errors);
-  process.exit(1);
-}
-
-console.log(`Sitemap check passed for ${contract.sitemapUrls.length} expected URLs.`);
+runCheck({
+  title: 'Sitemap check',
+  run(errors) {
+    errors.push(...verifySitemapXml(xml, contract).errors);
+  },
+  onSuccess() {
+    return `Sitemap check passed for ${contract.sitemapUrls.length} expected URLs.`;
+  },
+});

--- a/scripts/check-sitemap.js
+++ b/scripts/check-sitemap.js
@@ -1,56 +1,21 @@
 const fs = require('node:fs');
 const path = require('node:path');
+const { loadRouteRegistry, compileRouteContract, verifySitemapXml } = require('./lib/route-artifacts');
+const { printCheckErrors } = require('./lib/validation-core');
 
 const root = path.resolve(__dirname, '..');
 const errors = [];
 
-const registryPath = path.join(root, 'src/data/routes.json');
-const registry = JSON.parse(fs.readFileSync(registryPath, 'utf8'));
-
-const expectedUrls = [];
-for (const route of registry.routes) {
-  if (!route.sitemap) continue;
-  const url =
-    route.canonicalPath === '/'
-      ? `${registry.baseUrl}/`
-      : `${registry.baseUrl}${route.canonicalPath}`;
-  expectedUrls.push(url);
-}
-
-const expectedSet = new Set(expectedUrls);
+const registry = loadRouteRegistry(root);
+const contract = compileRouteContract(registry);
 
 const sitemapPath = path.join(root, 'sitemap.xml');
 const xml = fs.readFileSync(sitemapPath, 'utf8');
-
-const locRe = /<loc>([^<]+)<\/loc>/g;
-const locs = [...xml.matchAll(locRe)].map((m) => m[1]);
-
-for (const loc of locs) {
-  if (loc.includes('.html')) {
-    errors.push(`Sitemap contains legacy .html URL: ${loc}`);
-  }
-  const rootHome = `${registry.baseUrl}/`;
-  if (loc.endsWith('/') && loc !== rootHome) {
-    errors.push(`Sitemap loc must not end with trailing slash except root: ${loc}`);
-  }
-}
-
-for (const url of expectedUrls) {
-  if (!locs.includes(url)) {
-    errors.push(`Missing sitemap URL: ${url}`);
-  }
-}
-
-for (const loc of locs) {
-  if (!expectedSet.has(loc)) {
-    errors.push(`Unexpected sitemap URL: ${loc}`);
-  }
-}
+errors.push(...verifySitemapXml(xml, contract).errors);
 
 if (errors.length) {
-  console.error('Sitemap check failed:');
-  for (const error of errors) console.error(`- ${error}`);
+  printCheckErrors('Sitemap check', errors);
   process.exit(1);
 }
 
-console.log(`Sitemap check passed for ${expectedUrls.length} expected URLs.`);
+console.log(`Sitemap check passed for ${contract.sitemapUrls.length} expected URLs.`);

--- a/scripts/lib/route-artifacts.js
+++ b/scripts/lib/route-artifacts.js
@@ -1,0 +1,113 @@
+'use strict';
+
+const path = require('node:path');
+const { loadJson, normalizeCanonicalPath } = require('./validation-core');
+
+function loadRouteRegistry(root) {
+  return loadJson(root, 'src/data/routes.json');
+}
+
+function expectedSitemapUrls(registry) {
+  const urls = [];
+  for (const route of registry.routes || []) {
+    if (!route.sitemap) continue;
+    const url = route.canonicalPath === '/'
+      ? `${registry.baseUrl}/`
+      : `${registry.baseUrl}${route.canonicalPath}`;
+    urls.push(url);
+  }
+  return urls;
+}
+
+function compileRouteContract(registry) {
+  const baseUrl = String((registry && registry.baseUrl) || '').trim();
+  const sitemapUrls = expectedSitemapUrls(registry);
+  return {
+    registry,
+    baseUrl,
+    rootHome: `${baseUrl}/`,
+    sitemapUrls,
+    sitemapUrlSet: new Set(sitemapUrls),
+    canonicalToOutput: canonicalToOutputMap(registry),
+  };
+}
+
+function parseSitemapLocs(xml) {
+  const locRe = /<loc>([^<]+)<\/loc>/g;
+  return [...String(xml || '').matchAll(locRe)].map((m) => m[1]);
+}
+
+function verifySitemapXml(xml, contract, options = {}) {
+  const errors = [];
+  const opts = {
+    requireXmlHeader: false,
+    requireXmlns: false,
+    requireBaseUrl: false,
+    ...options,
+  };
+
+  const body = String(xml || '');
+  const locs = parseSitemapLocs(body);
+
+  if (opts.requireXmlHeader && !body.startsWith('<?xml version="1.0" encoding="UTF-8"?>')) {
+    errors.push('sitemap.xml must start with <?xml version="1.0" encoding="UTF-8"?>');
+  }
+
+  if (opts.requireXmlns && !body.includes('xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"')) {
+    errors.push('sitemap.xml must declare sitemap 0.9 xmlns');
+  }
+
+  for (const loc of locs) {
+    if (loc.includes('.html')) {
+      errors.push(`Sitemap contains legacy .html URL: ${loc}`);
+    }
+    if (loc.endsWith('/') && loc !== contract.rootHome) {
+      errors.push(`Sitemap loc must not end with trailing slash except root: ${loc}`);
+    }
+    if (opts.requireBaseUrl && !loc.startsWith(contract.baseUrl)) {
+      errors.push(`Sitemap loc must use base URL ${contract.baseUrl}: ${loc}`);
+    }
+  }
+
+  for (const url of contract.sitemapUrls) {
+    if (!locs.includes(url)) {
+      errors.push(`Missing sitemap URL: ${url}`);
+    }
+  }
+
+  for (const loc of locs) {
+    if (!contract.sitemapUrlSet.has(loc)) {
+      errors.push(`Unexpected sitemap URL: ${loc}`);
+    }
+  }
+
+  return { errors, locs };
+}
+
+function canonicalToOutputMap(registry) {
+  const map = new Map();
+  for (const route of registry.routes || []) {
+    const canonical = normalizeCanonicalPath(route.canonicalPath || '');
+    if (!canonical) continue;
+    map.set(canonical, String(route.outputFile || '').replace(/^\//, ''));
+  }
+  return map;
+}
+
+function resolveAbsoluteSiteHref(root, registry, href) {
+  const clean = normalizeCanonicalPath(href);
+  const map = canonicalToOutputMap(registry);
+  const rel = map.get(clean);
+  if (!rel) return null;
+  return path.join(root, rel);
+}
+
+module.exports = {
+  loadRouteRegistry,
+  expectedSitemapUrls,
+  compileRouteContract,
+  parseSitemapLocs,
+  verifySitemapXml,
+  canonicalToOutputMap,
+  resolveAbsoluteSiteHref,
+};

--- a/scripts/lib/validation-core.js
+++ b/scripts/lib/validation-core.js
@@ -1,0 +1,79 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+function loadJson(root, relPath) {
+  const abs = path.join(root, relPath);
+  return JSON.parse(fs.readFileSync(abs, 'utf8'));
+}
+
+function stripQueryAndHash(value) {
+  return String(value || '').split('#')[0].split('?')[0];
+}
+
+function normalizeCanonicalPath(raw) {
+  if (!raw || typeof raw !== 'string') return '';
+  let result = stripQueryAndHash(raw.trim());
+  if (result.startsWith('https://timemission.com')) {
+    result = result.slice('https://timemission.com'.length);
+  } else if (result.startsWith('http://timemission.com')) {
+    result = result.slice('http://timemission.com'.length);
+  }
+  if (!result.startsWith('/')) result = `/${result}`;
+  if (result.length > 1 && result.endsWith('/')) result = result.slice(0, -1);
+  return result;
+}
+
+function walkHtmlFiles(dir, files = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name.startsWith('.') || entry.name === 'node_modules') continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walkHtmlFiles(full, files);
+    } else if (entry.name.endsWith('.html')) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+function listDeployableHtmlPages(root) {
+  return walkHtmlFiles(root).filter((filePath) => {
+    const relative = path.relative(root, filePath);
+    return !relative.startsWith('assets/')
+      && !relative.startsWith('ads/')
+      && !relative.startsWith('components/')
+      && !relative.startsWith('dist/')
+      && !relative.startsWith('public/');
+  });
+}
+
+function printCheckErrors(title, errors) {
+  if (!errors.length) return;
+  console.error(`${title} failed:`);
+  for (const error of errors) console.error(`- ${error}`);
+}
+
+function runCheck({ title, run, onSuccess }) {
+  const errors = [];
+  run(errors);
+  if (errors.length) {
+    printCheckErrors(title, errors);
+    process.exit(1);
+  }
+  if (typeof onSuccess === 'function') {
+    console.log(onSuccess());
+    return;
+  }
+  console.log(`${title} passed.`);
+}
+
+module.exports = {
+  loadJson,
+  stripQueryAndHash,
+  normalizeCanonicalPath,
+  listDeployableHtmlPages,
+  printCheckErrors,
+  runCheck,
+};


### PR DESCRIPTION
## Summary
- Add `runCheck(...)` helper to `scripts/lib/validation-core.js` as a shared execution/reporting path for verification scripts.
- Migrate `check-booking-architecture`, `check-components`, `check-sitemap`, and `check-sitemap-output` to use the shared runner instead of duplicating error-print + exit boilerplate.
- Reuse `listDeployableHtmlPages(...)` in `check-components` to consolidate runtime page discovery in the validation core.

## Test plan
- [x] `npm run check:booking`
- [x] `npm run check:components`
- [x] `npm run check:sitemap`
- [x] `npm run check:sitemap-output`
- [x] `npm run check`
- [x] `npm run test:smoke`

Made with [Cursor](https://cursor.com)